### PR TITLE
-exportOptionsPlist doesn't support the 'none' method

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -212,7 +212,15 @@ tmp_dir=$(mktemp -d -t bitrise-xcarchive)
 
 export_command="$export_command -archivePath \"${archive_path}\""
 export_command="$export_command -exportPath \"${tmp_dir}/${scheme}.${export_format}\""
-export_command="$export_command -exportOptionsPlist \"${export_options_path}\""
+
+# It seems -exportOptionsPlist doesn't support the 'none' method, and
+# an absense of an explicit method defaults to 'development', so we
+# have to use the older, deprecated style in that case
+if [[ "${export_method}" == "none" ]]; then
+	export_command="$export_command -exportFormat APP"
+else
+	export_command="$export_command -exportOptionsPlist \"${export_options_path}\""
+fi
 
 if [[ "${output_tool}" == "xcpretty" ]] ; then
 	export_command="set -o pipefail && $export_command | xcpretty"


### PR DESCRIPTION
It seems -exportOptionsPlist doesn't support the 'none' method, and an absense of an explicit method defaults to 'development', so we have to use the older, deprecated style in that case. A bug report has been filed for this.
