### PR TITLE
Adding a zipped version of the .app file

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -238,9 +238,12 @@ IFS=$'\n'
 for a_file_path in $(find "$tmp_dir" -maxdepth 1 -mindepth 1 -type d)
 do
 	filename=$(basename "$a_file_path")
-	echo " -> moving file: ${a_file_path} to ${output_dir}"
+	app_zip_path="${output_dir}/${scheme}.${export_format}.zip"
+	echo " -> zipping file: ${a_file_path} to ${output_dir}"
 
 	mv "${a_file_path}" "${output_dir}"
+	cd ${output_dir}
+	/usr/bin/zip -rTy "${app_zip_path}" "${scheme}.${export_format}"
 
 	regex=".*.app"
 	if [[ "${filename}" =~ $regex ]] ; then


### PR DESCRIPTION
Currently there is no way of uploading the produced .app file to Bitrise after this step, as is outlined in this issue: https://github.com/vasarhelyia/steps-xcode-archive-mac/issues/5

This change will produce a zipped version of the .app file so that it will be picked up by the "Upload to Bitrise" step.

This has only been tested using the "none" export method, as I don't yet have the means to test the other methods.
