### PR TITLE
Zip only if export format is app

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -238,14 +238,20 @@ IFS=$'\n'
 for a_file_path in $(find "$tmp_dir" -maxdepth 1 -mindepth 1 -type d)
 do
 	filename=$(basename "$a_file_path")
-	app_zip_path="${output_dir}/${scheme}.${export_format}.zip"
-	echo " -> zipping file: ${a_file_path} to ${output_dir}"
+	if [[ "${export_format}" == "app" ]]; then
+		app_zip_path="${output_dir}/${scheme}.${export_format}.zip"
+	fi
 
 	mv "${a_file_path}" "${output_dir}"
-	cd ${output_dir}
-	/usr/bin/zip -rTy "${app_zip_path}" "${scheme}.${export_format}"
 
-	regex=".*.app"
+	if [[ ! -z "${app_zip_path}" ]]; then
+		echo " -> zipping file: ${a_file_path} to ${output_dir}"
+
+		cd ${output_dir}
+		/usr/bin/zip -rTy "${app_zip_path}" "${scheme}.${export_format}"
+	fi
+
+	regex=".*.${export_format}"
 	if [[ "${filename}" =~ $regex ]] ; then
 		if [[ -z "${exported_file_path}" ]] ; then
 			exported_file_path="${output_dir}/${filename}"


### PR DESCRIPTION
@Rheeseyb I decided to rather make some modifications, so it will work for `.pkg` outputs as well. Tried out with `none`, `development` and `app-store` exports.
