### PR TITLE
.xcarchive should be in the output directory

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -95,8 +95,7 @@ cd "${output_dir}"
 output_dir="$(pwd)"
 cd -
 
-archive_tmp_dir=$(mktemp -d -t bitrise-xcarchive)
-archive_path="${archive_tmp_dir}/${scheme}.xcarchive"
+archive_path="${output_dir}/${scheme}.xcarchive"
 file_path="${output_dir}/${scheme}.app"
 dsym_zip_path="${output_dir}/${scheme}.dSYM.zip"
 


### PR DESCRIPTION
According to Bitrise UI, after this step finishes the .xcarchive should be located in the output directory which doesn't seem to be the case.

>  <img width="597" alt="screen shot 2016-07-25 at 16 59 39" src="https://cloud.githubusercontent.com/assets/670571/17105957/a611cc4e-5289-11e6-9893-984b1b194f8f.png">

This pull request just removes the line creating a temporary location for the .xcarchive and creates it directly in the output directory.
